### PR TITLE
Update Dockerfile

### DIFF
--- a/ansible-automation/roles/baf/image/Dockerfile
+++ b/ansible-automation/roles/baf/image/Dockerfile
@@ -1,6 +1,6 @@
 FROM hyperledgerlabs/baf-build
 
-RUN apt-get install -y vim curl
+RUN apt-get install -y curl
 
 RUN curl -LO https://dl.k8s.io/release/v1.22.0/bin/linux/amd64/kubectl \
     && mv kubectl /usr/local/bin/ \


### PR DESCRIPTION
The vim is not available by default in ubuntu repo. This resolves baf_image build issue. vim is not used and not mandatory part of the build.