### PR TITLE
Vault helm chart version fix and vault cleanup namespace fix

### DIFF
--- a/ansible-automation/roles/vault/tasks/main.yaml
+++ b/ansible-automation/roles/vault/tasks/main.yaml
@@ -29,7 +29,8 @@
     --set server.ingress.enabled=true \
     --set server.ingress.hosts[0].host=vault.{{ env }}.{{ internal_domain }} \
     --set server.ingress.annotations."kubernetes\.io/ingress\.class"=haproxy \
-    --set server.dataStorage.storageClass=openidl-sc
+    --set server.dataStorage.storageClass=openidl-sc \
+    --version="0.16.1"
   tags:
     - hashicorp-vault
     - hashicorp-vault-helm

--- a/ansible-automation/vault-cleanup.yml
+++ b/ansible-automation/vault-cleanup.yml
@@ -20,7 +20,7 @@
 
     - name: delete vault namespace
       community.kubernetes.k8s:
-        name: openidl-baf
+        name: vault
         api_version: v1
         kind: Namespace
         state: absent


### PR DESCRIPTION
Vault helm deployment is failing because of changes in vault helm chart https://github.com/hashicorp/vault-helm in version v0.17.0 so reverting to install version v0.16.1 which is tested in earlier deployments.